### PR TITLE
Add Terraform infrastructure setup

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.100.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "srhoton-tfstate"
+    key    = "step-alb-poc/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,20 @@
+data "aws_vpc" "main_vpc" {
+  tags = {
+    Name = "dev-env-default_vpc"
+  }
+}
+
+data "aws_subnets" "public_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main_vpc.id]
+  }
+
+  tags = {
+    Name = "public-*"
+  }
+}
+
+data "aws_route53_zone" "steverhoton_com" {
+  zone_id = "Z0738030YKODO2ZBZ8JM"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,51 @@
+resource "aws_dynamodb_table" "step_alb_poc" {
+  name           = "step-alb-poc"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "PK"
+  range_key      = "SK"
+  stream_enabled = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "step-alb-poc"
+    Environment = "dev"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_lb" "step_alb_poc" {
+  name               = "step-alb-poc"
+  internal           = false
+  load_balancer_type = "application"
+  subnets            = data.aws_subnets.public_subnets.ids
+
+  enable_deletion_protection = false
+
+  tags = {
+    Name        = "step-alb-poc"
+    Environment = "dev"
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_route53_record" "step_alb_poc" {
+  zone_id = data.aws_route53_zone.steverhoton_com.zone_id
+  name    = "step-alb-poc.steverhoton.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.step_alb_poc.dns_name
+    zone_id                = aws_lb.step_alb_poc.zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
## Summary
- Set up Terraform with S3 backend for state management
- Add data sources for existing VPC, public subnets, and Route53 zone
- Create DynamoDB table with streams enabled for the application
- Deploy Application Load Balancer in public subnets
- Create Route53 alias record pointing step-alb-poc.steverhoton.com to ALB

## Test plan
- [x] Terraform configuration validates successfully
- [x] All resources deploy without errors
- [x] DynamoDB table created with correct schema (PK/SK) and streams
- [x] ALB deployed in correct subnets
- [x] Route53 record points to ALB correctly

🤖 Generated with [Claude Code](https://claude.ai/code)