### PR TITLE
Optimize DynamoDB operations by replacing scan with query

### DIFF
--- a/service-lambda/src/lambda_handler.py
+++ b/service-lambda/src/lambda_handler.py
@@ -8,6 +8,7 @@ from typing import Any, Dict
 
 import boto3
 from botocore.exceptions import ClientError
+from boto3.dynamodb.conditions import Key
 
 # Configure logging
 logger = logging.getLogger()
@@ -181,9 +182,8 @@ def handle_put(widget_name: str, body: str) -> Dict[str, Any]:
             )
 
         # Check if widget exists (get current state)
-        response = table.scan(
-            FilterExpression="PK = :pk",
-            ExpressionAttributeValues={":pk": widget_name}
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(widget_name)
         )
 
         if not response["Items"]:
@@ -240,9 +240,8 @@ def handle_get(widget_name: str) -> Dict[str, Any]:
     """
     try:
         # Get all records for this widget
-        response = table.scan(
-            FilterExpression="PK = :pk",
-            ExpressionAttributeValues={":pk": widget_name}
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(widget_name)
         )
 
         if not response["Items"]:
@@ -285,9 +284,8 @@ def handle_delete(widget_name: str) -> Dict[str, Any]:
     """
     try:
         # Get all records for this widget
-        response = table.scan(
-            FilterExpression="PK = :pk",
-            ExpressionAttributeValues={":pk": widget_name}
+        response = table.query(
+            KeyConditionExpression=Key("PK").eq(widget_name)
         )
 
         if not response["Items"]:


### PR DESCRIPTION
## Summary
- Replaced inefficient `scan()` operations with `query()` operations in the Lambda handler
- Added proper import for `Key` from `boto3.dynamodb.conditions`
- Improved performance by using KeyConditionExpression instead of FilterExpression

## Changes
- Updated `handle_put()`, `handle_get()`, and `handle_delete()` functions to use `table.query()` instead of `table.scan()`
- Added `from boto3.dynamodb.conditions import Key` import
- Used `KeyConditionExpression=Key("PK").eq(widget_name)` for efficient querying

## Performance Impact
DynamoDB `query()` operations are significantly more efficient than `scan()` operations as they use the table's primary key directly rather than scanning all items.

🤖 Generated with [Claude Code](https://claude.ai/code)